### PR TITLE
Update 12_dash_webserver.py

### DIFF
--- a/keras/12_dash_webserver.py
+++ b/keras/12_dash_webserver.py
@@ -1,6 +1,6 @@
 # -*- coding: utf-8 -*-
 
-from dash_html_components.Br import Br
+from dash.html.Br import Br
 import flask
 
 import dash


### PR DESCRIPTION
```
The dash_html_components package is deprecated. Please replace
`import dash_html_components as html` with `from dash import html`
```